### PR TITLE
JSONフォーマットに関する指定を追加

### DIFF
--- a/spreadsheetconverter/handler/json.py
+++ b/spreadsheetconverter/handler/json.py
@@ -9,7 +9,9 @@ from .valueformatter.string import ValueFormatter as StringValueFormatter
 class Handler(BaseHandler):
     def save(self, data):
         with open(self._config['path'], 'w') as f:
-            f.write(json.dumps(data))
+            indent = self._config.get('indent')
+            sort_keys = self._config.get('sort_keys', False)
+            f.write(json.dumps(data, indent=indent, sort_keys=sort_keys))
 
     def get_value_formatter(self, setting):
         if setting['type'] == 'datetime':


### PR DESCRIPTION
出力した JSON を何らかのバージョン管理で管理したい場合、各要素が改行で区切られていて、キーが一定の順序で並んでいる方が都合が良いため。
