### PR TITLE
foreignkey の lookup に失敗することがあるのを修正

### DIFF
--- a/spreadsheetconverter/config.py
+++ b/spreadsheetconverter/config.py
@@ -78,6 +78,9 @@ class Config(object):
         self._converter[item] = converter
         return converter
 
+    def get_converter_by_column(self, item):
+        return self.get_converter(self._fields_column[item]['name'])
+
     def get_formatter(self, item):
         if item in self._formatter:
             return self._formatter[item]

--- a/spreadsheetconverter/loader/valueconverter/foreignkey.py
+++ b/spreadsheetconverter/loader/valueconverter/foreignkey.py
@@ -8,9 +8,20 @@ class ValueConverter(BaseValueConverter):
     def __init__(self, settings):
         super(ValueConverter, self).__init__(settings)
         self._relation_data = {}
+        self._converter = None
 
     def to_python(self, value):
-        return self.relation[value]
+        return self.relation[self.converter.to_python(value)]
+
+    @property
+    def converter(self):
+        if self._converter:
+            return self._converter
+
+        from spreadsheetconverter import Converter
+        converter = Converter(self.settings['relation']['from'])
+        self._converter = converter.config.get_converter_by_column(self.relation_field_from)
+        return self._converter
 
     @property
     def relation(self):


### PR DESCRIPTION
`value` は xls ファイルから取得したままの値であり、`self.relation` のキーは、そのフィールド用に変換された値になっているからです。
`value` に対して適切な `Converter` で変換を掛けてからルックアップする必要があります。
